### PR TITLE
sets src_dir to current directory for data to upload

### DIFF
--- a/control.ipynb
+++ b/control.ipynb
@@ -84,7 +84,7 @@
    "outputs": [],
    "source": [
     "ds = ws.get_default_datastore()\n",
-    "mnist_data = ds.upload(src_dir = 'data', target_path = 'mnist', show_progress = True)"
+    "mnist_data = ds.upload(src_dir = '.', target_path = 'mnist', show_progress = True)"
    ]
   },
   {


### PR DESCRIPTION
We ran into this during the That Conference workshop, where the source directory for the workspace upload needs to be `.` rather than `data`.

(Thanks for the workshop!)